### PR TITLE
Added a 'dangerously' implemented fold-if

### DIFF
--- a/include/phism/mlir/Transforms/PhismTransforms.h
+++ b/include/phism/mlir/Transforms/PhismTransforms.h
@@ -11,6 +11,7 @@ namespace phism {
 void registerExtractTopFuncPass();
 void registerLoopTransformPasses();
 void registerArrayPartitionPasses();
+void registerFoldIfPasses();
 void registerAllPhismPasses();
 void registerDependenceAnalysisPasses();
 } // namespace phism

--- a/include/phism/mlir/Transforms/Utils.h
+++ b/include/phism/mlir/Transforms/Utils.h
@@ -1,10 +1,16 @@
 //===- Utils.h - Utility functions ------------------ C++-===//
 
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/OperationSupport.h"
 
 namespace phism {
 
 /// Get the top function for the hardware design.
 mlir::FuncOp getTopFunction(mlir::ModuleOp m);
+mlir::Value expandAffineExpr(mlir::OpBuilder &builder, mlir::Location loc,
+                             mlir::AffineExpr expr, mlir::ValueRange dimValues,
+                             mlir::ValueRange symbolValues);
 
 } // namespace phism

--- a/lib/mlir/Transforms/CMakeLists.txt
+++ b/lib/mlir/Transforms/CMakeLists.txt
@@ -4,6 +4,7 @@ add_mlir_library(PhismTransforms
   PhismTransforms.cc
   ArrayPartition.cc
   DependenceAnalysis.cc
+  FoldIf.cc
   Utils.cc
 
   ADDITIONAL_HEADER_DIRS

--- a/lib/mlir/Transforms/FoldIf.cc
+++ b/lib/mlir/Transforms/FoldIf.cc
@@ -1,0 +1,157 @@
+//===- FoldIf.cc - Fold affine.if into select ---------------- C++-===//
+#include "phism/mlir/Transforms/PhismTransforms.h"
+#include "phism/mlir/Transforms/Utils.h"
+
+#include "mlir/Analysis/AffineAnalysis.h"
+#include "mlir/Analysis/AffineStructures.h"
+#include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Analysis/Utils.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Affine/IR/AffineValueMap.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/IR/BlockAndValueMapping.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Dominance.h"
+#include "mlir/IR/IntegerSet.h"
+#include "mlir/IR/OpImplementation.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/Types.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/Passes.h"
+#include "mlir/Transforms/RegionUtils.h"
+#include "mlir/Transforms/Utils.h"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SetVector.h"
+
+#include <fstream>
+#include <queue>
+#include <set>
+
+#define DEBUG_TYPE "fold-if"
+
+using namespace mlir;
+using namespace llvm;
+using namespace phism;
+
+static void addEligibleAffineIfOps(FuncOp f,
+                                   SmallVector<mlir::AffineIfOp> &ifOps) {
+  f.walk([&](mlir::AffineIfOp ifOp) {
+    LLVM_DEBUG(dbgs() << "Num regions: " << ifOp.getNumRegions()
+                      << ", num blocks: "
+                      << ifOp.getBodyRegion().getBlocks().size() << '\n');
+    // There should be a single region with a single block.
+    if (ifOp.hasElse() || ifOp.getBodyRegion().getBlocks().size() > 1)
+      return;
+    // TODO: other conditions
+    ifOps.push_back(ifOp);
+  });
+}
+
+static Value createAffineIfCond(mlir::AffineIfOp ifOp, OpBuilder &b) {
+  Location loc = ifOp.getLoc();
+
+  IntegerSet integerSet = ifOp.getIntegerSet();
+  Value zeroConstant = b.create<ConstantIndexOp>(loc, 0);
+  SmallVector<Value, 8> operands(ifOp.getOperands());
+  auto operandsRef = llvm::makeArrayRef(operands);
+
+  Value cond = nullptr;
+
+  for (unsigned i = 0, e = integerSet.getNumConstraints(); i < e; ++i) {
+    AffineExpr constraintExpr = integerSet.getConstraint(i);
+    bool isEquality = integerSet.isEq(i);
+
+    auto numDims = integerSet.getNumDims();
+    Value affResult = expandAffineExpr(b, loc, constraintExpr,
+                                       operandsRef.take_front(numDims),
+                                       operandsRef.drop_front(numDims));
+    if (!affResult)
+      return nullptr;
+
+    auto pred = isEquality ? CmpIPredicate::eq : CmpIPredicate::sge;
+    Value cmpVal = b.create<mlir::CmpIOp>(loc, pred, affResult, zeroConstant);
+    cond = cond ? b.create<AndOp>(loc, cond, cmpVal).getResult() : cmpVal;
+  }
+
+  return cond ? cond : b.create<ConstantIntOp>(loc, /*value=*/1, /*width=*/1);
+}
+
+/// The value to be store is either the original value to be stored, or the
+/// current value at this given address.
+static LogicalResult process(mlir::AffineStoreOp storeOp, Value cond,
+                             BlockAndValueMapping &vmap, OpBuilder &b) {
+  Location loc = storeOp.getLoc();
+
+  Value memref = storeOp.getMemRef();
+  AffineMap affMap = storeOp.getAffineMap();
+  SmallVector<Value, 8> mapOperands(storeOp.getMapOperands());
+
+  Value orig = b.create<mlir::AffineLoadOp>(loc, memref, affMap, mapOperands);
+  Value toStore = b.create<SelectOp>(
+      loc, cond, vmap.lookup(storeOp.getValueToStore()), orig);
+
+  b.create<mlir::AffineStoreOp>(loc, toStore, memref, affMap, mapOperands);
+
+  return success();
+}
+
+/// TODO: filter invalid operations.
+/// TODO: affine.load might load from invalid address.
+static LogicalResult process(mlir::AffineIfOp ifOp, OpBuilder &b) {
+  OpBuilder::InsertionGuard guard(b);
+  b.setInsertionPointAfter(ifOp);
+
+  // Turn the if-condition evaluation result to a single value.
+  // This implementation is inspired by AffineIfLowering from AffineToStandard.
+  Value cond = createAffineIfCond(ifOp, b);
+  if (!cond)
+    return failure();
+
+  BlockAndValueMapping vmap;
+  for (Operation &op : ifOp.getBody()->getOperations()) {
+    if (isa<mlir::AffineYieldOp>(op))
+      continue;
+
+    if (auto storeOp = dyn_cast<mlir::AffineStoreOp>(op)) {
+      if (failed(process(storeOp, cond, vmap, b)))
+        return failure();
+    } else {
+      b.clone(op, vmap);
+    }
+  }
+
+  ifOp.erase();
+
+  return success();
+}
+
+namespace {
+struct FoldIfPass : PassWrapper<FoldIfPass, OperationPass<ModuleOp>> {
+  void runOnOperation() override {
+    ModuleOp m = getOperation();
+    OpBuilder b(m.getContext());
+
+    SmallVector<mlir::AffineIfOp> ifOps;
+    m.walk([&](FuncOp f) { addEligibleAffineIfOps(f, ifOps); });
+
+    for (mlir::AffineIfOp ifOp : ifOps)
+      if (failed(process(ifOp, b)))
+        LLVM_DEBUG(dbgs() << "Failed to process: " << ifOp << '\n');
+  }
+};
+} // namespace
+
+namespace phism {
+void registerFoldIfPasses() {
+
+  PassPipelineRegistration<>("fold-if", "Fold affine.if",
+                             [&](OpPassManager &pm) {
+                               pm.addPass(std::make_unique<FoldIfPass>());
+                               //  pm.addPass(createCanonicalizerPass());
+                             });
+}
+} // namespace phism

--- a/lib/mlir/Transforms/PhismTransforms.cc
+++ b/lib/mlir/Transforms/PhismTransforms.cc
@@ -13,6 +13,7 @@ void registerAllPhismPasses() {
   registerExtractTopFuncPass();
   registerArrayPartitionPasses();
   registerDependenceAnalysisPasses();
+  registerFoldIfPasses();
 }
 
 } // namespace phism

--- a/lib/mlir/Transforms/Utils.cc
+++ b/lib/mlir/Transforms/Utils.cc
@@ -2,11 +2,211 @@
 
 #include "phism/mlir/Transforms/Utils.h"
 
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/SCF.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/Dialect/Vector/VectorOps.h"
+#include "mlir/IR/AffineExprVisitor.h"
+#include "mlir/IR/BlockAndValueMapping.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/IntegerSet.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/Passes.h"
 
 using namespace mlir;
 using namespace llvm;
 using namespace phism;
+
+/// Copied from AffineToStandard.cpp
+namespace {
+/// Visit affine expressions recursively and build the sequence of operations
+/// that correspond to it.  Visitation functions return an Value of the
+/// expression subtree they visited or `nullptr` on error.
+class AffineApplyExpander
+    : public AffineExprVisitor<AffineApplyExpander, Value> {
+public:
+  /// This internal class expects arguments to be non-null, checks must be
+  /// performed at the call site.
+  AffineApplyExpander(OpBuilder &builder, ValueRange dimValues,
+                      ValueRange symbolValues, Location loc)
+      : builder(builder), dimValues(dimValues), symbolValues(symbolValues),
+        loc(loc) {}
+
+  template <typename OpTy> Value buildBinaryExpr(AffineBinaryOpExpr expr) {
+    auto lhs = visit(expr.getLHS());
+    auto rhs = visit(expr.getRHS());
+    if (!lhs || !rhs)
+      return nullptr;
+    auto op = builder.create<OpTy>(loc, lhs, rhs);
+    return op.getResult();
+  }
+
+  Value visitAddExpr(AffineBinaryOpExpr expr) {
+    return buildBinaryExpr<AddIOp>(expr);
+  }
+
+  Value visitMulExpr(AffineBinaryOpExpr expr) {
+    return buildBinaryExpr<MulIOp>(expr);
+  }
+
+  /// Euclidean modulo operation: negative RHS is not allowed.
+  /// Remainder of the euclidean integer division is always non-negative.
+  ///
+  /// Implemented as
+  ///
+  ///     a mod b =
+  ///         let remainder = srem a, b;
+  ///             negative = a < 0 in
+  ///         select negative, remainder + b, remainder.
+  Value visitModExpr(AffineBinaryOpExpr expr) {
+    auto rhsConst = expr.getRHS().dyn_cast<AffineConstantExpr>();
+    if (!rhsConst) {
+      emitError(
+          loc,
+          "semi-affine expressions (modulo by non-const) are not supported");
+      return nullptr;
+    }
+    if (rhsConst.getValue() <= 0) {
+      emitError(loc, "modulo by non-positive value is not supported");
+      return nullptr;
+    }
+
+    auto lhs = visit(expr.getLHS());
+    auto rhs = visit(expr.getRHS());
+    assert(lhs && rhs && "unexpected affine expr lowering failure");
+
+    Value remainder = builder.create<SignedRemIOp>(loc, lhs, rhs);
+    Value zeroCst = builder.create<ConstantIndexOp>(loc, 0);
+    Value isRemainderNegative =
+        builder.create<CmpIOp>(loc, CmpIPredicate::slt, remainder, zeroCst);
+    Value correctedRemainder = builder.create<AddIOp>(loc, remainder, rhs);
+    Value result = builder.create<SelectOp>(loc, isRemainderNegative,
+                                            correctedRemainder, remainder);
+    return result;
+  }
+
+  /// Floor division operation (rounds towards negative infinity).
+  ///
+  /// For positive divisors, it can be implemented without branching and with a
+  /// single division operation as
+  ///
+  ///        a floordiv b =
+  ///            let negative = a < 0 in
+  ///            let absolute = negative ? -a - 1 : a in
+  ///            let quotient = absolute / b in
+  ///                negative ? -quotient - 1 : quotient
+  Value visitFloorDivExpr(AffineBinaryOpExpr expr) {
+    auto rhsConst = expr.getRHS().dyn_cast<AffineConstantExpr>();
+    if (!rhsConst) {
+      emitError(
+          loc,
+          "semi-affine expressions (division by non-const) are not supported");
+      return nullptr;
+    }
+    if (rhsConst.getValue() <= 0) {
+      emitError(loc, "division by non-positive value is not supported");
+      return nullptr;
+    }
+
+    auto lhs = visit(expr.getLHS());
+    auto rhs = visit(expr.getRHS());
+    assert(lhs && rhs && "unexpected affine expr lowering failure");
+
+    Value zeroCst = builder.create<ConstantIndexOp>(loc, 0);
+    Value noneCst = builder.create<ConstantIndexOp>(loc, -1);
+    Value negative =
+        builder.create<CmpIOp>(loc, CmpIPredicate::slt, lhs, zeroCst);
+    Value negatedDecremented = builder.create<SubIOp>(loc, noneCst, lhs);
+    Value dividend =
+        builder.create<SelectOp>(loc, negative, negatedDecremented, lhs);
+    Value quotient = builder.create<SignedDivIOp>(loc, dividend, rhs);
+    Value correctedQuotient = builder.create<SubIOp>(loc, noneCst, quotient);
+    Value result =
+        builder.create<SelectOp>(loc, negative, correctedQuotient, quotient);
+    return result;
+  }
+
+  /// Ceiling division operation (rounds towards positive infinity).
+  ///
+  /// For positive divisors, it can be implemented without branching and with a
+  /// single division operation as
+  ///
+  ///     a ceildiv b =
+  ///         let negative = a <= 0 in
+  ///         let absolute = negative ? -a : a - 1 in
+  ///         let quotient = absolute / b in
+  ///             negative ? -quotient : quotient + 1
+  Value visitCeilDivExpr(AffineBinaryOpExpr expr) {
+    auto rhsConst = expr.getRHS().dyn_cast<AffineConstantExpr>();
+    if (!rhsConst) {
+      emitError(loc) << "semi-affine expressions (division by non-const) are "
+                        "not supported";
+      return nullptr;
+    }
+    if (rhsConst.getValue() <= 0) {
+      emitError(loc, "division by non-positive value is not supported");
+      return nullptr;
+    }
+    auto lhs = visit(expr.getLHS());
+    auto rhs = visit(expr.getRHS());
+    assert(lhs && rhs && "unexpected affine expr lowering failure");
+
+    Value zeroCst = builder.create<ConstantIndexOp>(loc, 0);
+    Value oneCst = builder.create<ConstantIndexOp>(loc, 1);
+    Value nonPositive =
+        builder.create<CmpIOp>(loc, CmpIPredicate::sle, lhs, zeroCst);
+    Value negated = builder.create<SubIOp>(loc, zeroCst, lhs);
+    Value decremented = builder.create<SubIOp>(loc, lhs, oneCst);
+    Value dividend =
+        builder.create<SelectOp>(loc, nonPositive, negated, decremented);
+    Value quotient = builder.create<SignedDivIOp>(loc, dividend, rhs);
+    Value negatedQuotient = builder.create<SubIOp>(loc, zeroCst, quotient);
+    Value incrementedQuotient = builder.create<AddIOp>(loc, quotient, oneCst);
+    Value result = builder.create<SelectOp>(loc, nonPositive, negatedQuotient,
+                                            incrementedQuotient);
+    return result;
+  }
+
+  Value visitConstantExpr(AffineConstantExpr expr) {
+    auto valueAttr =
+        builder.getIntegerAttr(builder.getIndexType(), expr.getValue());
+    auto op =
+        builder.create<ConstantOp>(loc, builder.getIndexType(), valueAttr);
+    return op.getResult();
+  }
+
+  Value visitDimExpr(AffineDimExpr expr) {
+    assert(expr.getPosition() < dimValues.size() &&
+           "affine dim position out of range");
+    return dimValues[expr.getPosition()];
+  }
+
+  Value visitSymbolExpr(AffineSymbolExpr expr) {
+    assert(expr.getPosition() < symbolValues.size() &&
+           "symbol dim position out of range");
+    return symbolValues[expr.getPosition()];
+  }
+
+private:
+  OpBuilder &builder;
+  ValueRange dimValues;
+  ValueRange symbolValues;
+
+  Location loc;
+};
+} // namespace
+
+/// Create a sequence of operations that implement the `expr` applied to the
+/// given dimension and symbol values.
+namespace phism {
+mlir::Value expandAffineExpr(OpBuilder &builder, Location loc, AffineExpr expr,
+                             ValueRange dimValues, ValueRange symbolValues) {
+  return AffineApplyExpander(builder, dimValues, symbolValues, loc).visit(expr);
+}
+} // namespace phism
 
 static bool hasPeCaller(FuncOp f) {
   bool ret = false;

--- a/pyphism/polybench/pb_flow.py
+++ b/pyphism/polybench/pb_flow.py
@@ -1229,6 +1229,7 @@ class PbFlow:
             src_file,
             f'-loop-transforms="max-span={self.options.max_span}"',
             "-loop-redis-and-merge",
+            "-fold-if",
             "-debug-only=loop-transforms",
         ]
 

--- a/test/mlir/Transforms/FoldIfPass/fold-if.mlir
+++ b/test/mlir/Transforms/FoldIfPass/fold-if.mlir
@@ -1,0 +1,25 @@
+// RUN: phism-opt -fold-if %s | FileCheck %s
+
+#set = affine_set<(d0) : (d0 - 5 >= 0)>
+
+// CHECK-LABEL: func @square_last_half
+func @square_last_half(%A: memref<10xf32>) {
+  affine.for %i = 0 to 10 {
+    affine.if #set(%i) {
+      %0 = affine.load %A[%i] : memref<10xf32>
+      %1 = mulf %0, %0 : f32
+      affine.store %1, %A[%i] : memref<10xf32>
+    }  
+  }
+  return
+}
+
+// CHECK: %[[C0:.*]] = constant 0 : index
+// CHECK: %[[C5:.*]] = constant -5 : index
+// CHECK: %[[VAL0:.*]] = addi %{{.*}}, %[[C5]] : index
+// CHECK: %[[VAL1:.*]] = cmpi sge, %[[VAL0]], %[[C0]] : index
+// CHECK: %[[VAL2:.*]] = affine.load 
+// CHECK: %[[VAL3:.*]] = mulf %[[VAL2]], %[[VAL2]] : f32
+// CHECK: %[[VAL4:.*]] = affine.load %[[ARG0:.*]][%[[ARG1:.*]]] : memref<10xf32>
+// CHECK: %[[VAL5:.*]] = select %[[VAL1]], %[[VAL3]], %[[VAL4]] : f32
+// CHECK: affine.store %[[VAL5]], %[[ARG0]][%[[ARG1]]] : memref<10xf32>


### PR DESCRIPTION
`-fold-if` can turn affine.if that has a single block in the body into an equivalent version that uses select.

Note that this is a very early-stage implementation and there can be caveats.