### PR TITLE
[ElimLoadStore] created -eliminate-affine-load-store

### DIFF
--- a/include/phism/mlir/Transforms/Passes.h
+++ b/include/phism/mlir/Transforms/Passes.h
@@ -8,6 +8,9 @@ namespace phism {
 std::unique_ptr<mlir::OperationPass<mlir::FuncOp>>
 createLoopBoundHoistingPass();
 
+std::unique_ptr<mlir::OperationPass<mlir::FuncOp>>
+createEliminateAffineLoadStorePass();
+
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "phism/mlir/Transforms/Passes.h.inc"

--- a/include/phism/mlir/Transforms/Passes.td
+++ b/include/phism/mlir/Transforms/Passes.td
@@ -9,4 +9,13 @@ def LoopBoundHoisting : FunctionPass<"loop-bound-hoisting"> {
   let constructor = "phism::createLoopBoundHoistingPass()";
 }
 
+def EliminateAffineLoadStore : FunctionPass<"eliminate-affine-load-store"> {
+  let summary = "Eliminate redundant affine load and store operations.";
+  let constructor = "phism::createEliminateAffineLoadStorePass()";
+  let options = [
+    Option<"loadAfterStore", "load-after-store", "bool", /*default=*/"true",
+           "Whether to perform load-after-store elimination">
+  ];
+}
+
 #endif

--- a/lib/mlir/Transforms/CMakeLists.txt
+++ b/lib/mlir/Transforms/CMakeLists.txt
@@ -5,6 +5,7 @@ add_mlir_library(PhismTransforms
   ArrayPartition.cc
   FoldIf.cc
   LoopBoundHoisting.cc
+  EliminateAffineLoadStore.cc
   Utils.cc
 
   ADDITIONAL_HEADER_DIRS

--- a/lib/mlir/Transforms/EliminateAffineLoadStore.cc
+++ b/lib/mlir/Transforms/EliminateAffineLoadStore.cc
@@ -1,0 +1,204 @@
+//===- EliminateAffineLoadStore.cc ------------------------------*- C++ -*-===//
+//
+// Implements a pass that eliminates redundant affine load store operations.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetail.h"
+
+#include "mlir/Analysis/AffineAnalysis.h"
+#include "mlir/Analysis/AffineStructures.h"
+#include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Analysis/Utils.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Affine/IR/AffineValueMap.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/BlockAndValueMapping.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Dominance.h"
+#include "mlir/IR/IntegerSet.h"
+#include "mlir/IR/OpImplementation.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/Types.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/LoopUtils.h"
+#include "mlir/Transforms/Passes.h"
+#include "mlir/Transforms/RegionUtils.h"
+#include "mlir/Transforms/Utils.h"
+
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "eliminate-affine-load-store"
+
+using namespace mlir;
+using namespace llvm;
+using namespace phism;
+
+using AccessOpList = std::pair<MemRefAccess, SmallVector<Operation *>>;
+
+/// Iterate every operations in the block. Put load and store operations into
+/// the corresponding memref access buckets. If there is an operation that has
+/// blocks, they will be a NULL separator in every bucket.
+static void getAccessOps(Block *block,
+                         SmallVectorImpl<AccessOpList> &accessOps) {
+  for (Operation &op : *block) {
+    if (!isa<mlir::AffineLoadOp, mlir::AffineStoreOp>(op)) {
+      // If there appears to be a inner block, we currently assume it can
+      // have side effects on all the memref accesses.
+      // We insert an delimeter (NULL) to all the existing accessOps lists.
+      if (op.getNumRegions() >= 1)
+        for (auto &p : accessOps)
+          p.second.push_back(nullptr);
+
+      continue;
+    }
+
+    // Insert or create.
+    MemRefAccess access(&op);
+    auto it = find_if(accessOps,
+                      [&](const AccessOpList &p) { return p.first == access; });
+    if (it == accessOps.end())
+      accessOps.push_back({access, SmallVector<Operation *>{&op}});
+    else
+      it->second.push_back(&op);
+  }
+}
+
+/// For each block under the provided function, we find all the load
+/// operations to each accessed address. If multiple loads to the same address
+/// have no interleaved store operations (to the same address), we merge them
+/// into one.
+///
+/// An address being accessed is considered the same if
+static LogicalResult eliminateIdenticalAffineLoadOps(FuncOp f, OpBuilder &b) {
+
+  std::function<void(Block *)> processBlock = [&](Block *block) {
+    SmallVector<AccessOpList, 4> accessOps;
+    getAccessOps(block, accessOps);
+
+    LLVM_DEBUG({
+      dbgs() << "Resolved memref accesses and their operations:\n";
+      for (auto &p : accessOps) {
+        p.first.memref.dump();
+        for (Operation *op : p.second) {
+          if (op)
+            op->dump();
+          else
+            dbgs() << "NULL\n";
+        }
+        dbgs() << "\n";
+      }
+    });
+
+    // Eliminate redundant load operations.
+    for (auto &p : accessOps) {
+      Operation *curr = nullptr;
+      for (Operation *op : p.second) {
+        if (isa_and_nonnull<mlir::AffineLoadOp>(op)) {
+          // If there is no replace target, set curr.
+          if (!curr)
+            curr = op;
+          else { // Carry out replacement.
+            op->replaceAllUsesWith(curr);
+            op->erase();
+          }
+        } else {
+          // Reset the front load operation in each section.
+          curr = nullptr;
+        }
+      }
+    }
+
+    // Process internal blocks.
+    for (Operation &op : *block)
+      for (Region &region : op.getRegions())
+        for (Block &blk : region)
+          processBlock(&blk);
+  };
+
+  for (Block &block : f.getBody())
+    processBlock(&block);
+
+  return success();
+}
+
+/// In cases that an affine.load follows an affine.store that operate on the
+/// same address, we will try to eliminate them and replace the use of the load
+/// by the values to be stored.
+static LogicalResult eliminateLoadAfterStore(FuncOp f, OpBuilder &b) {
+  std::function<void(Block *)> processBlock = [&](Block *block) {
+    SmallVector<AccessOpList, 4> accessOps;
+    getAccessOps(block, accessOps);
+
+    for (auto &p : accessOps) {
+      auto &ops = p.second;
+
+      // Keeps the last-seen affine.store operation.
+      Operation *prevStore = nullptr;
+      // Keeps all the stores that should be erased, in visiting order.
+      SmallVector<Operation *> storesToErase;
+
+      for (auto op : enumerate(ops)) {
+        if (isa_and_nonnull<mlir::AffineLoadOp>(op.value())) { // load
+          if (prevStore) {
+            op.value()->getResult(0).replaceAllUsesWith(
+                prevStore->getOperand(0));
+            op.value()->erase();
+          }
+        } else if (isa_and_nonnull<mlir::AffineStoreOp>(op.value())) { // store
+          prevStore = op.value();
+          storesToErase.push_back(op.value());
+        } else { // block
+          assert(!op.value());
+          // Remove the last store operation from the stack.
+          if (!storesToErase.empty())
+            storesToErase.pop_back();
+        }
+      }
+
+      // The last store should be kept.
+      if (!storesToErase.empty())
+        storesToErase.pop_back();
+
+      for (Operation *op : storesToErase)
+        op->erase();
+    }
+
+    // Process internal blocks.
+    for (Operation &op : *block)
+      for (Region &region : op.getRegions())
+        for (Block &blk : region)
+          processBlock(&blk);
+  };
+
+  for (Block &block : f.getBody())
+    processBlock(&block);
+
+  return success();
+}
+
+namespace {
+struct EliminateAffineLoadStore
+    : public EliminateAffineLoadStoreBase<EliminateAffineLoadStore> {
+
+  void runOnFunction() override {
+    FuncOp f = getOperation();
+    OpBuilder b(f.getContext());
+
+    if (failed(eliminateIdenticalAffineLoadOps(f, b)) ||
+        (loadAfterStore && failed(eliminateLoadAfterStore(f, b)))) {
+      signalPassFailure();
+      return;
+    }
+  }
+};
+} // namespace
+
+std::unique_ptr<mlir::OperationPass<mlir::FuncOp>>
+phism::createEliminateAffineLoadStorePass() {
+  return std::make_unique<EliminateAffineLoadStore>();
+}

--- a/lib/mlir/Transforms/PhismTransforms.cc
+++ b/lib/mlir/Transforms/PhismTransforms.cc
@@ -16,6 +16,7 @@ void registerAllPhismPasses() {
   // registerDependenceAnalysisPasses();
   registerFoldIfPasses();
   registerLoopBoundHoistingPass();
+  registerEliminateAffineLoadStorePass();
 }
 
 } // namespace phism

--- a/test/mlir/Transforms/EliminateAffineLoadStore/load-after-store-interleaved.mlir
+++ b/test/mlir/Transforms/EliminateAffineLoadStore/load-after-store-interleaved.mlir
@@ -1,0 +1,17 @@
+// RUN: phism-opt %s -eliminate-affine-load-store | FileCheck %s
+
+func @foo(%A: memref<?xf32>, %i: index, %a: f32) -> f32 {
+  affine.store %a, %A[%i] : memref<?xf32>
+  // this store shouldn't be removed.
+  %v = affine.load %A[%i] : memref<?xf32>
+  affine.for %t = 0 to 2 {}
+  affine.store %a, %A[%i] : memref<?xf32>
+  return %v : f32
+}
+
+// CHECK: func @foo(%[[A:.*]]: memref<?xf32>, %[[i:.*]]: index, %[[a:.*]]: f32)
+// CHECK-NEXT: affine.store %[[a]], %[[A]][%[[i]]]
+// CHECK-NEXT: affine.for
+// CHECK-NEXT: }
+// CHECK-NEXT: affine.store %[[a]], %[[A]][%[[i]]]
+// CHECK-NEXT: return %[[a]]

--- a/test/mlir/Transforms/EliminateAffineLoadStore/load-after-store.mlir
+++ b/test/mlir/Transforms/EliminateAffineLoadStore/load-after-store.mlir
@@ -1,0 +1,12 @@
+// RUN: phism-opt %s -eliminate-affine-load-store | FileCheck %s 
+
+func @foo(%A: memref<?xf32>, %i: index, %a: f32) -> f32 {
+  affine.store %a, %A[%i] : memref<?xf32>
+  %v = affine.load %A[%i] : memref<?xf32>
+  affine.store %a, %A[%i] : memref<?xf32>
+  return %v : f32
+}
+
+// CHECK: func @foo(%[[A:.*]]: memref<?xf32>, %[[i:.*]]: index, %[[a:.*]]: f32)
+// CHECK-NEXT: affine.store %[[a]], %[[A]][%[[i]]]
+// CHECK-NEXT: return %[[a]]

--- a/test/mlir/Transforms/EliminateAffineLoadStore/same-load-ops-interleaved.mlir
+++ b/test/mlir/Transforms/EliminateAffineLoadStore/same-load-ops-interleaved.mlir
@@ -1,0 +1,20 @@
+// RUN: phism-opt %s -eliminate-affine-load-store='load-after-store=0' | FileCheck %s
+
+// All the loads won't be eliminated.
+func @foo(%A: memref<?xi32>, %i: index, %a: i32) -> i32 {
+  %fst = affine.load %A[%i] : memref<?xi32>
+  affine.store %a, %A[%i] : memref<?xi32>
+  %snd = affine.load %A[%i] : memref<?xi32>
+  affine.for %t = 0 to 2 {}
+  %trd = affine.load %A[%i] : memref<?xi32>
+  return %snd : i32
+}
+
+// CHECK: func @foo
+// CHECK-NEXT: affine.load
+// CHECK-NEXT: affine.store
+// CHECK-NEXT: affine.load
+// CHECK-NEXT: affine.for
+// CHECK-NEXT: }
+// CHECK-NEXT: affine.load
+// CHECK-NEXT: return

--- a/test/mlir/Transforms/EliminateAffineLoadStore/same-load-ops.mlir
+++ b/test/mlir/Transforms/EliminateAffineLoadStore/same-load-ops.mlir
@@ -1,0 +1,31 @@
+// RUN: phism-opt %s -eliminate-affine-load-store | FileCheck %s
+
+func @foo(%A: memref<?xi32>) {
+  %fst = affine.load %A[0] : memref<?xi32>
+  %fst2 = affine.load %A[0] : memref<?xi32>
+  // Should only leave one.
+
+  affine.for %i = 1 to 10 {
+    %cur1 = affine.load %A[%i] : memref<?xi32>
+    %cur2 = affine.load %A[%i] : memref<?xi32>
+    %next = affine.load %A[%i + 1] : memref<?xi32> // should not remove
+
+    %doubled = arith.addi %cur1, %cur2 : i32
+    %sum = arith.addi %next, %doubled : i32
+    %final = arith.addi %fst2, %sum : i32
+
+    affine.store %final, %A[100 + %i] : memref<?xi32>
+  }
+
+  return
+}
+
+// CHECK: func @foo(%[[A:.*]]: memref<?xi32>)
+// CHECK-NEXT: %[[v0:.*]] = affine.load %[[A]][0]
+// CHECK-NEXT: affine.for %[[i:.*]] = 1 to 10
+// CHECK-NEXT: %[[v1:.*]] = affine.load %[[A]][%[[i]]]
+// CHECK-NEXT: %[[v2:.*]] = affine.load %[[A]][%[[i]] + 1]
+// CHECK-NEXT: %[[v3:.*]] = arith.addi %[[v1]], %[[v1]]
+// CHECK-NEXT: %[[v4:.*]] = arith.addi %[[v2]], %[[v3]]
+// CHECK-NEXT: %[[v5:.*]] = arith.addi %[[v0]], %[[v4]]
+// CHECK-NEXT: affine.store %[[v5]], %[[A]][%[[i]] + 100]


### PR DESCRIPTION
```mlir
func @foo(%A: memref<?xf32>, %i: index, %a: f32) -> f32 {
  affine.store %a, %A[%i] : memref<?xf32>
  %v = affine.load %A[%i] : memref<?xf32>
  affine.store %a, %A[%i] : memref<?xf32>
  return %v : f32
}
```

will be squashed into

```mlir
func @foo(%A: memref<?xf32>, %i: index, %a: f32) -> f32 {
  affine.store %a, %A[%i] : memref<?xf32>
  return %a : f32
}
```

-----

```mlir
func @foo(%A: memref<?xi32>) {
  %fst = affine.load %A[0] : memref<?xi32>
  %fst2 = affine.load %A[0] : memref<?xi32>
  // Should only leave one.

  affine.for %i = 1 to 10 {
    %cur1 = affine.load %A[%i] : memref<?xi32>
    %cur2 = affine.load %A[%i] : memref<?xi32>
    %next = affine.load %A[%i + 1] : memref<?xi32> // should not remove

    %doubled = arith.addi %cur1, %cur2 : i32
    %sum = arith.addi %next, %doubled : i32
    %final = arith.addi %fst2, %sum : i32

    affine.store %final, %A[100 + %i] : memref<?xi32>
  }

  return
}
```

will be simplified to

```mlir
func @foo(%A: memref<?xi32>) {
  %fst = affine.load %A[0] : memref<?xi32>

  affine.for %i = 1 to 10 {
    %cur1 = affine.load %A[%i] : memref<?xi32>
    %next = affine.load %A[%i + 1] : memref<?xi32> // should not remove

    %doubled = arith.addi %cur1, %cur1 : i32
    %sum = arith.addi %next, %doubled : i32
    %final = arith.addi %fst, %sum : i32

    affine.store %final, %A[100 + %i] : memref<?xi32>
  }

  return
}

```

